### PR TITLE
Implement toString() for ManagedExecutor and ThreadContext.

### DIFF
--- a/cdi/src/main/java/io/smallrye/concurrency/inject/SmallryeConcurrencyCdiExtension.java
+++ b/cdi/src/main/java/io/smallrye/concurrency/inject/SmallryeConcurrencyCdiExtension.java
@@ -15,6 +15,8 @@
  */
 package io.smallrye.concurrency.inject;
 
+import io.smallrye.concurrency.impl.ManagedExecutorBuilderImpl;
+import io.smallrye.concurrency.impl.ThreadContextBuilderImpl;
 import org.eclipse.microprofile.concurrent.ManagedExecutor;
 import org.eclipse.microprofile.concurrent.ManagedExecutorConfig;
 import org.eclipse.microprofile.concurrent.NamedInstance;
@@ -169,7 +171,8 @@ public class SmallryeConcurrencyCdiExtension implements Extension {
                         // bean is ApplicationScoped, ME.shutdown() is called only after whole app is being shutdown
                         t.shutdown();
                     })
-                    .createWith(param -> ManagedExecutor.builder()
+                    .createWith(param -> ((ManagedExecutorBuilderImpl)ManagedExecutor.builder())
+                            .injectionPointName(entry.getKey().getMpConfigName())
                             .maxAsync(resolveConfiguration(entry.getKey().getMpConfigName() + MEConfig + maxAsync,
                                     Integer.class, annotation.maxAsync()))
                             .maxQueued(resolveConfiguration(entry.getKey().getMpConfigName() + MEConfig + maxQueued,
@@ -191,7 +194,8 @@ public class SmallryeConcurrencyCdiExtension implements Extension {
                         // bean is ApplicationScoped, ME.shutdown() is called only after whole app is being shutdown
                         t.shutdown();
                     })
-                    .createWith(param -> ManagedExecutor.builder()
+                    .createWith(param -> ((ManagedExecutorBuilderImpl)ManagedExecutor.builder())
+                            .injectionPointName(ipName.getMpConfigName())
                             .maxAsync(resolveConfiguration(ipName.getMpConfigName() + MEConfig + maxAsync,
                                     Integer.class, ManagedExecutorConfig.Literal.DEFAULT_INSTANCE.maxAsync()))
                             .maxQueued(resolveConfiguration(ipName.getMpConfigName() + MEConfig + maxQueued,
@@ -213,7 +217,8 @@ public class SmallryeConcurrencyCdiExtension implements Extension {
                     .disposeWith((ThreadContext t, Instance<Object> u) -> {
                         // no-op at this point
                     })
-                    .createWith(param -> ThreadContext.builder()
+                    .createWith(param -> ((ThreadContextBuilderImpl)ThreadContext.builder())
+                            .injectionPointName(entry.getKey().getMpConfigName())
                             .cleared(resolveConfiguration(entry.getKey().getMpConfigName() + TCConfig + cleared,
                                     String[].class, annotation.cleared()))
                             .unchanged(resolveConfiguration(entry.getKey().getMpConfigName() + TCConfig + unchanged,
@@ -233,7 +238,8 @@ public class SmallryeConcurrencyCdiExtension implements Extension {
                     .disposeWith((ThreadContext t, Instance<Object> u) -> {
                         // no-op
                     })
-                    .createWith(param -> ThreadContext.builder()
+                    .createWith(param -> ((ThreadContextBuilderImpl)ThreadContext.builder())
+                            .injectionPointName(ipName.getMpConfigName())
                             .cleared(resolveConfiguration(ipName.getMpConfigName() + TCConfig + cleared,
                                     String[].class, ThreadContextConfig.Literal.DEFAULT_INSTANCE.cleared()))
                             .unchanged(resolveConfiguration(ipName.getMpConfigName() + TCConfig + unchanged,

--- a/core/src/main/java/io/smallrye/concurrency/impl/ManagedExecutorBuilderImpl.java
+++ b/core/src/main/java/io/smallrye/concurrency/impl/ManagedExecutorBuilderImpl.java
@@ -13,6 +13,7 @@ public class ManagedExecutorBuilderImpl implements ManagedExecutor.Builder {
     private int maxQueued;
     private String[] propagated;
     private String[] cleared;
+    private String injectionPointName = null;
 
     public ManagedExecutorBuilderImpl(SmallRyeConcurrencyManager manager) {
         this.manager = manager;
@@ -26,7 +27,7 @@ public class ManagedExecutorBuilderImpl implements ManagedExecutor.Builder {
     @Override
     public ManagedExecutor build() {
         return new ManagedExecutorImpl(maxAsync, maxQueued,
-                new ThreadContextImpl(manager, propagated, SmallRyeConcurrencyManager.NO_STRING, cleared));
+                new ThreadContextImpl(manager, propagated, SmallRyeConcurrencyManager.NO_STRING, cleared), injectionPointName);
     }
 
     @Override
@@ -56,6 +57,11 @@ public class ManagedExecutorBuilderImpl implements ManagedExecutor.Builder {
     @Override
     public Builder cleared(String... types) {
         this.cleared = types;
+        return this;
+    }
+
+    public ManagedExecutor.Builder injectionPointName(String name) {
+        this.injectionPointName = name;
         return this;
     }
 

--- a/core/src/main/java/io/smallrye/concurrency/impl/ThreadContextBuilderImpl.java
+++ b/core/src/main/java/io/smallrye/concurrency/impl/ThreadContextBuilderImpl.java
@@ -10,6 +10,7 @@ public class ThreadContextBuilderImpl implements ThreadContext.Builder {
     private String[] unchanged;
     private String[] cleared;
     private SmallRyeConcurrencyManager manager;
+    private String injectionPointName = null;
 
     public ThreadContextBuilderImpl(SmallRyeConcurrencyManager manager) {
         this.manager = manager;
@@ -20,7 +21,7 @@ public class ThreadContextBuilderImpl implements ThreadContext.Builder {
 
     @Override
     public ThreadContext build() {
-        return new ThreadContextImpl(manager, propagated, unchanged, cleared);
+        return new ThreadContextImpl(manager, propagated, unchanged, cleared, injectionPointName);
     }
 
     @Override
@@ -38,6 +39,11 @@ public class ThreadContextBuilderImpl implements ThreadContext.Builder {
     @Override
     public ThreadContext.Builder cleared(String... types) {
         cleared = types;
+        return this;
+    }
+
+    public ThreadContext.Builder injectionPointName(String name) {
+        this.injectionPointName = name;
         return this;
     }
 


### PR DESCRIPTION
Add `toString()` impls to ME and TC.
When there is a CDI injection point, an information about what's stored under `NamedInstance` qualifier is added as well.

Spec says we should include fully qualified name of IP as well, but that information seems redundant. I have raised a question on Gitter and if need be will address that separately.