### PR TITLE
issue33 Make UserTransaction available via CDI

### DIFF
--- a/tck/src/test/java/io/smallrye/concurrency/tck/SmallRyeConcurrencyArchiveProcessor.java
+++ b/tck/src/test/java/io/smallrye/concurrency/tck/SmallRyeConcurrencyArchiveProcessor.java
@@ -17,10 +17,12 @@ package io.smallrye.concurrency.tck;
 
 import java.io.File;
 
+import io.smallrye.concurrency.tck.cdi.UserTransactionProducer;
 import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
 import org.jboss.arquillian.test.spi.TestClass;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
@@ -50,6 +52,8 @@ public class SmallRyeConcurrencyArchiveProcessor implements ApplicationArchivePr
                 archive.addAsLibrary(newJar);
             }
             archive.addAsResource("jndi.properties");
+            archive.addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+            archive.addClass(UserTransactionProducer.class);
         }
         if (applicationArchive instanceof JavaArchive) {
             // TODO, add impl for JARs, we would need to add them as packages or

--- a/tck/src/test/java/io/smallrye/concurrency/tck/cdi/UserTransactionProducer.java
+++ b/tck/src/test/java/io/smallrye/concurrency/tck/cdi/UserTransactionProducer.java
@@ -1,0 +1,16 @@
+package io.smallrye.concurrency.tck.cdi;
+
+import com.arjuna.ats.jta.UserTransaction;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Produces;
+
+@Dependent
+public class UserTransactionProducer {
+    @Produces
+    @ApplicationScoped
+    public javax.transaction.UserTransaction userTransaction() {
+        return UserTransaction.userTransaction();
+    }
+}

--- a/tck/src/test/java/io/smallrye/concurrency/tck/lifecycle/LifecycleExecuter.java
+++ b/tck/src/test/java/io/smallrye/concurrency/tck/lifecycle/LifecycleExecuter.java
@@ -59,19 +59,19 @@ public class LifecycleExecuter {
 
    public void executeAfterDeploy(@Observes AfterDeploy event, TestClass testClass) throws Exception {
       registerJTA();
-      execute(testClass.getMethods(io.smallrye.concurrency.tck.lifecycle.api.AfterDeploy.class));
+      execute("AfterDeploy", testClass.getMethods(io.smallrye.concurrency.tck.lifecycle.api.AfterDeploy.class));
    }
    
    public void executeBeforeUnDeploy(@Observes BeforeUnDeploy event, TestClass testClass) throws Exception {
       unregisterJTA();
-      execute(testClass.getMethods(io.smallrye.concurrency.tck.lifecycle.api.BeforeUnDeploy.class));
+      execute("BeforeUnDeploy", testClass.getMethods(io.smallrye.concurrency.tck.lifecycle.api.BeforeUnDeploy.class));
    }
 
 /*   public void executeAfterUnDeploy(@Observes AfterUnDeploy event, TestClass testClass) {
       execute(testClass.getMethods(io.smallrye.concurrency.tck.lifecycle.api.AfterUnDeploy.class));
    }*/
 
-   private void execute(Method[] methods)
+   private void execute(String msg, Method[] methods)
    {
       if(methods == null)
       {
@@ -85,7 +85,7 @@ public class LifecycleExecuter {
          }
          catch (Exception e) 
          {
-            throw new RuntimeException("Could not execute @BeforeDeploy method: " + method, e);
+            throw new RuntimeException(msg + ":  Could not execute method: " + method, e);
          }
       }
    }

--- a/tests/src/main/java/io/smallrye/concurrency/test/jta/UserTransactionProducer.java
+++ b/tests/src/main/java/io/smallrye/concurrency/test/jta/UserTransactionProducer.java
@@ -1,0 +1,15 @@
+package io.smallrye.concurrency.test.jta;
+import com.arjuna.ats.jta.UserTransaction;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Produces;
+
+@Dependent
+public class UserTransactionProducer {
+    @Produces
+    @ApplicationScoped
+    public javax.transaction.UserTransaction userTransaction() {
+        return UserTransaction.userTransaction();
+    }
+}


### PR DESCRIPTION
Signed-off-by: Michael Musgrove <mmusgrov@redhat.com>

#33 

This PR adds support for running the MP Concurrency TCK against containers that do not automatically expose UserTransaction (such as the one used by the SmallRye concurrency implementation).