### PR TITLE
Re-introduce config annotations for injection, define our defaults, allow for MP config override

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>smallrye-concurrency-parent</artifactId>
+        <groupId>io.smallrye</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>smallrye-concurrency-api</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.microprofile.concurrency</groupId>
+            <artifactId>microprofile-concurrency-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/api/src/main/java/io/smallrye/concurrency/api/ManagedExecutorConfig.java
+++ b/api/src/main/java/io/smallrye/concurrency/api/ManagedExecutorConfig.java
@@ -38,16 +38,16 @@ import java.lang.annotation.Target;
  * <p>For example, the following injection points share a single
  * {@link ManagedExecutor} instance,</p>
  *
- * <pre><code> &commat;Inject &commat;NamedInstance("exec1") &commat;ManagedExecutorConfig(maxAsync=5)
+ * <pre><code> {@literal @}Inject {@literal @}NamedInstance("exec1") {@literal @}ManagedExecutorConfig(maxAsync=5)
  * ManagedExecutor executor;
  *
- * &commat;Inject
- * void setCompletableFuture(&commat;NamedInstance("exec1") ManagedExecutor exec) {
+ * {@literal @}Inject
+ * void setCompletableFuture({@literal @}NamedInstance("exec1") ManagedExecutor exec) {
  *     completableFuture = exec.newIncompleteFuture();
  * }
  *
- * &commat;Inject
- * void setCompletionStage(&commat;NamedInstance("exec1") ManagedExecutor exec) {
+ * {@literal @}Inject
+ * void setCompletionStage({@literal @}NamedInstance("exec1") ManagedExecutor exec) {
  *     completionStage = exec.supplyAsync(supplier);
  * }
  * </code></pre>
@@ -55,10 +55,10 @@ import java.lang.annotation.Target;
  * <p>Alternatively, the following injection points each represent a distinct
  * {@link ManagedExecutor} instance,</p>
  *
- * <pre><code> &commat;Inject &commat;ManagedExecutorConfig(propagated=ThreadContext.CDI)
+ * <pre><code> {@literal @}Inject {@literal @}ManagedExecutorConfig(propagated=ThreadContext.CDI)
  * ManagedExecutor exec2;
  *
- * &commat;Inject &commat;ManagedExecutorConfig(maxAsync=5)
+ * {@literal @}Inject {@literal @}ManagedExecutorConfig(maxAsync=5)
  * ManagedExecutor exec3;
  * </code></pre>
  *

--- a/api/src/main/java/io/smallrye/concurrency/api/ManagedExecutorConfig.java
+++ b/api/src/main/java/io/smallrye/concurrency/api/ManagedExecutorConfig.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2018,2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.concurrency.api;
+
+import org.eclipse.microprofile.concurrent.ManagedExecutor;
+import org.eclipse.microprofile.concurrent.ThreadContext;
+
+import javax.enterprise.util.AnnotationLiteral;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <p>Annotates a CDI injection point for a {@link ManagedExecutor} such that the container
+ * creates a new instance, which is identified within an application by its unique name.
+ * The unique name is generated as the fully qualified class name (with each component delimited by <code>.</code>)
+ * and the injection point's field name or method name and parameter position, all delimited by <code>/</code>,
+ * unless annotated with the {@link NamedInstance} qualifier,
+ * in which case the unique name is specified by the {@link NamedInstance#value} attribute of that qualifier.</p>
+ *
+ * <p>For example, the following injection points share a single
+ * {@link ManagedExecutor} instance,</p>
+ *
+ * <pre><code> &commat;Inject &commat;NamedInstance("exec1") &commat;ManagedExecutorConfig(maxAsync=5)
+ * ManagedExecutor executor;
+ *
+ * &commat;Inject
+ * void setCompletableFuture(&commat;NamedInstance("exec1") ManagedExecutor exec) {
+ *     completableFuture = exec.newIncompleteFuture();
+ * }
+ *
+ * &commat;Inject
+ * void setCompletionStage(&commat;NamedInstance("exec1") ManagedExecutor exec) {
+ *     completionStage = exec.supplyAsync(supplier);
+ * }
+ * </code></pre>
+ *
+ * <p>Alternatively, the following injection points each represent a distinct
+ * {@link ManagedExecutor} instance,</p>
+ *
+ * <pre><code> &commat;Inject &commat;ManagedExecutorConfig(propagated=ThreadContext.CDI)
+ * ManagedExecutor exec2;
+ *
+ * &commat;Inject &commat;ManagedExecutorConfig(maxAsync=5)
+ * ManagedExecutor exec3;
+ * </code></pre>
+ *
+ * <p>When the application stops, the container automatically shuts down instances
+ * of {@link ManagedExecutor} that it created. The application can manually use the
+ * {@link ManagedExecutor#shutdown} or {@link ManagedExecutor#shutdownNow} methods
+ * to shut down a managed executor at an earlier point.</p>
+ *
+ * <p>A <code>ManagedExecutor</code> will fail to inject, raising
+ * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException} on application startup,
+ * if multiple injection points are annotated to create instances with the same name.</p>
+ *
+ * @author Matej Novotny
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.TYPE, ElementType.PARAMETER})
+public @interface ManagedExecutorConfig {
+    /**
+     * <p>Defines the set of thread context types to clear from the thread
+     * where the action or task executes. The previous context is resumed
+     * on the thread after the action or task ends.</p>
+     *
+     * <p>By default, no context is cleared/suspended from execution thread.</p>
+     *
+     * <p>{@link ThreadContext#ALL_REMAINING} is automatically appended to the
+     * set of cleared context if the {@link #propagated} set does not include
+     * {@link ThreadContext#ALL_REMAINING}.</p>
+     *
+     * <p>Constants for specifying some of the core context types are provided
+     * on {@link ThreadContext}. Other thread context types must be defined
+     * by the specification that defines the context type or by a related
+     * MicroProfile specification.</p>
+     *
+     * <p>A <code>ManagedExecutor</code> must fail to inject, raising
+     * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException}
+     * on application startup,
+     * if a context type specified within this set is unavailable
+     * or if the {@link #propagated} set includes one or more of the
+     * same types as this set.</p>
+     */
+    String[] cleared() default {};
+
+    /**
+     * <p>Defines the set of thread context types to capture from the thread
+     * that creates a dependent stage (or that submits a task) and which to
+     * propagate to the thread where the action or task executes.</p>
+     *
+     * <p>The default set of propagated thread context types is
+     * {@link ThreadContext#ALL_REMAINING}, which includes all available
+     * thread context types that support capture and propagation to other
+     * threads, except for those that are explicitly {@code cleared}.</p>
+     *
+     * <p>Constants for specifying some of the core context types are provided
+     * on {@link ThreadContext}. Other thread context types must be defined
+     * by the specification that defines the context type or by a related
+     * MicroProfile specification.</p>
+     *
+     * <p>Thread context types which are not otherwise included in this set
+     * are cleared from the thread of execution for the duration of the
+     * action or task.</p>
+     *
+     * <p>A <code>ManagedExecutor</code> must fail to inject, raising
+     * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException}
+     * on application startup,
+     * if a context type specified within this set is unavailable
+     * or if the {@link #cleared} set includes one or more of the
+     * same types as this set.</p>
+     */
+    String[] propagated() default {ThreadContext.ALL_REMAINING};
+
+    /**
+     * <p>Establishes an upper bound on the number of async completion stage
+     * actions and async executor tasks that can be running at any given point
+     * in time. Async actions and tasks remain queued until
+     * the <code>ManagedExecutor</code> starts executing them.</p>
+     *
+     * <p>The default value of <code>-1</code> indicates no upper bound,
+     * although practically, resource constraints of the system will apply.</p>
+     *
+     * <p>A <code>ManagedExecutor</code> must fail to inject, raising
+     * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException}
+     * on application startup, if the
+     * <code>maxAsync</code> value is 0 or less than -1.
+     */
+    int maxAsync() default -1;
+
+    /**
+     * <p>Establishes an upper bound on the number of async actions and async tasks
+     * that can be queued up for execution. Async actions and tasks are rejected
+     * if no space in the queue is available to accept them.</p>
+     *
+     * <p>The default value of <code>-1</code> indicates no upper bound,
+     * although practically, resource constraints of the system will apply.</p>
+     *
+     * <p>A <code>ManagedExecutor</code> must fail to inject, raising
+     * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException}
+     * on application startup, if the
+     * <code>maxQueued</code> value is 0 or less than -1.
+     */
+    int maxQueued() default -1;
+
+    /**
+     * Util class used for inline creation of {@link ManagedExecutorConfig} annotation instances.
+     */
+    final class Literal extends AnnotationLiteral<ManagedExecutorConfig> implements ManagedExecutorConfig {
+
+        public static final Literal DEFAULT_INSTANCE =
+                of(-1, -1, new String[]{}, new String[]{ThreadContext.ALL_REMAINING});
+
+        private static final long serialVersionUID = 1L;
+
+        private final int maxAsync;
+        private final int maxQueued;
+        private final String[] cleared;
+        private final String[] propagated;
+
+        private Literal(int maxAsync, int maxQueued, String[] cleared, String[] propagated) {
+            this.cleared = cleared;
+            this.propagated = propagated;
+            this.maxAsync = maxAsync;
+            this.maxQueued = maxQueued;
+        }
+
+        public static Literal of(int maxAsync, int maxQueued, String[] cleared, String[] propagated) {
+            return new Literal(maxAsync, maxQueued, cleared, propagated);
+        }
+
+        public int maxAsync() {
+            return maxAsync;
+        }
+
+        public int maxQueued() {
+            return maxQueued;
+        }
+
+        public String[] cleared() {
+            return cleared;
+        }
+
+        public String[] propagated() {
+            return propagated;
+        }
+    }
+}

--- a/api/src/main/java/io/smallrye/concurrency/api/NamedInstance.java
+++ b/api/src/main/java/io/smallrye/concurrency/api/NamedInstance.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2018,2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.concurrency.api;
+
+import org.eclipse.microprofile.concurrent.ManagedExecutor;
+import org.eclipse.microprofile.concurrent.ThreadContext;
+
+import javax.enterprise.util.AnnotationLiteral;
+import javax.inject.Qualifier;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <p>This annotation is used to achieve out of the box {@link ManagedExecutor} and {@link ThreadContext} instance
+ * sharing through CDI injection.</p>
+ *
+ * <p>Qualifies a CDI injection point for a {@link ManagedExecutor} or {@link ThreadContext} with a unique name
+ * across the application.</p>
+ *
+ * <p>This annotation can be used in combination with the {@link ManagedExecutorConfig} or
+ * {@link ThreadContextConfig} annotation to define a new instance. For example,</p>
+ *
+ * <pre><code> &commat;Inject &commat;NamedInstance("myExecutor") &commat;ManagedExecutorConfig(maxAsync=10)
+ * ManagedExecutor myExecutor;
+ *
+ * &commat;Inject &commat;NamedInstance("myContext") &commat;ThreadContextConfig(propagated = { ThreadContext.SECURITY, ThreadContext.CDI })
+ * ThreadContext myThreadContext;
+ * </code></pre>
+ *
+ * <p>Once used as shown above, this annotation can be used on its own to qualify an injection point with the name of
+ * an existing instance. Injection points with the same {@link NamedInstance#value()} then share the same
+ * underlying contextual instance. For example, referencing a name from the previous example,</p>
+ *
+ * <pre><code> &commat;Inject &commat;NamedInstance("myExecutor")
+ * ManagedExecutor exec1;
+ *
+ * &commat;Inject &commat;NamedInstance("myContext")
+ * ThreadContext myContextPropagator;
+ * </code></pre>
+ *
+ * <p>Alternatively, an application can use this annotation as a normal CDI qualifier,
+ * defining its own scope, producer, and disposer. For example,</p>
+ *
+ * @author Matej Novotny
+ */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.TYPE, ElementType.PARAMETER })
+public @interface NamedInstance {
+    /**
+     * Unique name that qualifies a {@link ManagedExecutor} or {@link ThreadContext}.
+     */
+    String value();
+
+    /**
+     * Supports inline instantiation of the {@link NamedInstance} qualifier.
+     */
+    final class Literal extends AnnotationLiteral<NamedInstance> implements NamedInstance {
+
+        private static final long serialVersionUID = 1L;
+        private final String value;
+
+        private Literal(String value) {
+            this.value = value;
+        }
+
+        public static Literal of(String value) {
+            return new Literal(value);
+        }
+
+        public String value() {
+            return value;
+        }
+    }
+}

--- a/api/src/main/java/io/smallrye/concurrency/api/NamedInstance.java
+++ b/api/src/main/java/io/smallrye/concurrency/api/NamedInstance.java
@@ -38,10 +38,10 @@ import java.lang.annotation.Target;
  * <p>This annotation can be used in combination with the {@link ManagedExecutorConfig} or
  * {@link ThreadContextConfig} annotation to define a new instance. For example,</p>
  *
- * <pre><code> &commat;Inject &commat;NamedInstance("myExecutor") &commat;ManagedExecutorConfig(maxAsync=10)
+ * <pre><code> {@literal @}Inject {@literal @}NamedInstance("myExecutor") {@literal @}ManagedExecutorConfig(maxAsync=10)
  * ManagedExecutor myExecutor;
  *
- * &commat;Inject &commat;NamedInstance("myContext") &commat;ThreadContextConfig(propagated = { ThreadContext.SECURITY, ThreadContext.CDI })
+ * {@literal @}Inject {@literal @}NamedInstance("myContext") {@literal @}ThreadContextConfig(propagated = { ThreadContext.SECURITY, ThreadContext.CDI })
  * ThreadContext myThreadContext;
  * </code></pre>
  *
@@ -49,10 +49,10 @@ import java.lang.annotation.Target;
  * an existing instance. Injection points with the same {@link NamedInstance#value()} then share the same
  * underlying contextual instance. For example, referencing a name from the previous example,</p>
  *
- * <pre><code> &commat;Inject &commat;NamedInstance("myExecutor")
+ * <pre><code> {@literal @}Inject {@literal @}NamedInstance("myExecutor")
  * ManagedExecutor exec1;
  *
- * &commat;Inject &commat;NamedInstance("myContext")
+ * {@literal @}Inject {@literal @}NamedInstance("myContext")
  * ThreadContext myContextPropagator;
  * </code></pre>
  *

--- a/api/src/main/java/io/smallrye/concurrency/api/ThreadContextConfig.java
+++ b/api/src/main/java/io/smallrye/concurrency/api/ThreadContextConfig.java
@@ -21,6 +21,10 @@ package io.smallrye.concurrency.api;
 import org.eclipse.microprofile.concurrent.ThreadContext;
 
 import javax.enterprise.util.AnnotationLiteral;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * <p>Annotates a CDI injection point for a {@link ThreadContext} such that the container
@@ -69,6 +73,8 @@ import javax.enterprise.util.AnnotationLiteral;
  *
  * @author Matej Novotny
  */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.TYPE, ElementType.PARAMETER})
 public @interface ThreadContextConfig {
     /**
      * <p>Defines the set of thread context types to clear from the thread
@@ -93,7 +99,7 @@ public @interface ThreadContextConfig {
      * or if the {@link #propagated} and/or {@link #unchanged} set
      * includes one or more of the same types as this set.</p>
      */
-    String[] cleared() default {ThreadContext.TRANSACTION};
+    String[] cleared() default {};
 
     /**
      * <p>Defines the set of thread context types to capture from the thread

--- a/api/src/main/java/io/smallrye/concurrency/api/ThreadContextConfig.java
+++ b/api/src/main/java/io/smallrye/concurrency/api/ThreadContextConfig.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2018,2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.concurrency.api;
+
+import org.eclipse.microprofile.concurrent.ThreadContext;
+
+import javax.enterprise.util.AnnotationLiteral;
+
+/**
+ * <p>Annotates a CDI injection point for a {@link ThreadContext} such that the container
+ * creates a new instance, which is identified within an application by its unique name.
+ * The unique name is generated as the fully qualified class name (with each component delimited by <code>.</code>)
+ * and the injection point's field name or method name and parameter position, all delimited by <code>/</code>,
+ * unless annotated with the {@link NamedInstance} qualifier,
+ * in which case the unique name is specified by the {@link NamedInstance#value value} attribute of that qualifier.</p>
+ *
+ * <p>For example, the following injection points share a single
+ * {@link ThreadContext} instance,</p>
+ *
+ * <pre><code> &commat;Inject &commat;NamedInstance("tc1") &commat;ThreadContextConfig(propagated = { ThreadContext.CDI, ThreadContext.APPLICATION })
+ * ThreadContext threadContext1;
+ *
+ * &commat;Inject
+ * void setTask(&commat;NamedInstance("tc1") ThreadContext contextPropagator) {
+ *     task = contextPropagator.contextualTask(...);
+ * }
+ *
+ * &commat;Inject
+ * void setContextSnapshot(&commat;NamedInstance("tc1") ThreadContext contextPropagator) {
+ *     contextSnapshot = contextPropagator.currentContextExecutor();
+ * }
+ * </code></pre>
+ *
+ * <p>Alternatively, the following injection points each represent a distinct
+ * {@link ThreadContext} instance,</p>
+ *
+ * <pre><code> &commat;Inject &commat;ThreadContextConfig(propagated = { ThreadContext.SECURITY, ThreadContext.APPLICATION })
+ * ThreadContext tc2;
+ *
+ * &commat;Inject &commat;ThreadContextConfig(cleared = ThreadContext.SECURITY, unchanged = ThreadContext.TRANSACTION)
+ * ThreadContext tc3;
+ * </code></pre>
+ *
+ * <p>A <code>ThreadContext</code> will fail to inject, raising
+ * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException}
+ * on application startup,
+ * if multiple injection points are annotated to create instances with the same name.</p>
+ *
+ * <p>A <code>ThreadContext</code> must fail to inject, raising
+ * {@link javax.enterprise.inject.spi.DeploymentException DeploymentException}
+ * on application startup, if more than one provider provides the same thread context
+ * {@link org.eclipse.microprofile.concurrent.spi.ThreadContextProvider#getThreadContextType type}.
+ *
+ * @author Matej Novotny
+ */
+public @interface ThreadContextConfig {
+    /**
+     * <p>Defines the set of thread context types to clear from the thread
+     * where the action or task executes. The previous context is resumed
+     * on the thread after the action or task ends.</p>
+     *
+     * <p>By default, no context is cleared/suspended from execution thread.</p>
+     *
+     * <p>{@link ThreadContext#ALL_REMAINING} is automatically appended to the
+     * set of cleared context if neither the {@link #propagated} set nor the
+     * {@link #unchanged} set include {@link ThreadContext#ALL_REMAINING}.</p>
+     *
+     * <p>Constants for specifying some of the core context types are provided
+     * on {@link ThreadContext}. Other thread context types must be defined
+     * by the specification that defines the context type or by a related
+     * MicroProfile specification.</p>
+     *
+     * <p>A <code>ThreadContext</code> must fail to inject, raising
+     * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException}
+     * on application startup,
+     * if a context type specified within this set is unavailable
+     * or if the {@link #propagated} and/or {@link #unchanged} set
+     * includes one or more of the same types as this set.</p>
+     */
+    String[] cleared() default {ThreadContext.TRANSACTION};
+
+    /**
+     * <p>Defines the set of thread context types to capture from the thread
+     * that contextualizes an action or task. This context is later
+     * re-established on the thread(s) where the action or task executes.</p>
+     *
+     * <p>The default set of propagated thread context types is
+     * {@link ThreadContext#ALL_REMAINING}, which includes all available
+     * thread context types that support capture and propagation to other
+     * threads, except for those that are explicitly {@code cleared}.</p>
+     *
+     * <p>Constants for specifying some of the core context types are provided
+     * on {@link ThreadContext}. Other thread context types must be defined
+     * by the specification that defines the context type or by a related
+     * MicroProfile specification.</p>
+     *
+     * <p>Thread context types which are not otherwise included in this set or
+     * in the {@link #unchanged} set are cleared from the thread of execution
+     * for the duration of the action or task.</p>
+     *
+     * <p>A <code>ThreadContext</code> must fail to inject, raising
+     * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException}
+     * on application startup,
+     * if a context type specified within this set is unavailable
+     * or if the {@link #cleared} and/or {@link #unchanged} set
+     * includes one or more of the same types as this set.</p>
+     */
+    String[] propagated() default {ThreadContext.ALL_REMAINING};
+
+    /**
+     * <p>Defines a set of thread context types that are essentially ignored,
+     * in that they are neither captured nor are they propagated or cleared
+     * from thread(s) that execute the action or task.</p>
+     *
+     * <p>Constants for specifying some of the core context types are provided
+     * on {@link ThreadContext}. Other thread context types must be defined
+     * by the specification that defines the context type or by a related
+     * MicroProfile specification.
+     *
+     * <p>The configuration <code>unchanged</code> context is provided for
+     * advanced patterns where it is desirable to leave certain context types
+     * on the executing thread.</p>
+     *
+     * <p>For example, to run as the current application, but under the
+     * transaction of the thread where the task executes:</p>
+     * <pre><code> &commat;Inject &commat;ThreadContextConfig(unchanged = ThreadContext.TRANSACTION,
+     *                              propagated = ThreadContext.APPLICATION,
+     *                              cleared = ThreadContext.ALL_REMAINING)
+     * ThreadContext threadContext;
+     * ...
+     * task = threadContext.contextualRunnable(new MyTransactionalTask());
+     * ...
+     * // on another thread,
+     * tx.begin();
+     * ...
+     * task.run(); // runs under the transaction due to 'unchanged'
+     * tx.commit();
+     * </code></pre>
+     *
+     * <p>A <code>ThreadContext</code> must fail to inject, raising
+     * {@link javax.enterprise.inject.spi.DefinitionException DefinitionException}
+     * on application startup,
+     * if a context type specified within this set is unavailable
+     * or if the {@link #cleared} and/or {@link #propagated} set
+     * includes one or more of the same types as this set.</p>
+     */
+    String[] unchanged() default {};
+
+    /**
+     * Util class used for inline creation of {@link ThreadContextConfig} annotation instances.
+     */
+    final class Literal extends AnnotationLiteral<ThreadContextConfig> implements ThreadContextConfig {
+
+        public static final Literal DEFAULT_INSTANCE =
+                of(new String[]{}, new String[]{}, new String[]{ThreadContext.ALL_REMAINING});
+
+        private static final long serialVersionUID = 1L;
+
+        private final String[] cleared;
+        private final String[] unchanged;
+        private final String[] propagated;
+
+        private Literal(String[] cleared, String[] unchanged, String[] propagated) {
+            this.cleared = cleared;
+            this.unchanged = unchanged;
+            this.propagated = propagated;
+        }
+
+        public static Literal of(String[] cleared, String[] unchanged, String[] propagated) {
+            return new Literal(cleared, unchanged, propagated);
+        }
+
+        public String[] cleared() {
+            return cleared;
+        }
+
+        public String[] unchanged() {
+            return unchanged;
+        }
+
+        public String[] propagated() {
+            return propagated;
+        }
+    }
+}

--- a/api/src/main/java/io/smallrye/concurrency/api/ThreadContextConfig.java
+++ b/api/src/main/java/io/smallrye/concurrency/api/ThreadContextConfig.java
@@ -37,16 +37,16 @@ import java.lang.annotation.Target;
  * <p>For example, the following injection points share a single
  * {@link ThreadContext} instance,</p>
  *
- * <pre><code> &commat;Inject &commat;NamedInstance("tc1") &commat;ThreadContextConfig(propagated = { ThreadContext.CDI, ThreadContext.APPLICATION })
+ * <pre><code> {@literal @}Inject {@literal @}NamedInstance("tc1") {@literal @}ThreadContextConfig(propagated = { ThreadContext.CDI, ThreadContext.APPLICATION })
  * ThreadContext threadContext1;
  *
- * &commat;Inject
- * void setTask(&commat;NamedInstance("tc1") ThreadContext contextPropagator) {
+ * {@literal @}Inject
+ * void setTask({@literal @}NamedInstance("tc1") ThreadContext contextPropagator) {
  *     task = contextPropagator.contextualTask(...);
  * }
  *
- * &commat;Inject
- * void setContextSnapshot(&commat;NamedInstance("tc1") ThreadContext contextPropagator) {
+ * {@literal @}Inject
+ * void setContextSnapshot({@literal @}NamedInstance("tc1") ThreadContext contextPropagator) {
  *     contextSnapshot = contextPropagator.currentContextExecutor();
  * }
  * </code></pre>
@@ -54,10 +54,10 @@ import java.lang.annotation.Target;
  * <p>Alternatively, the following injection points each represent a distinct
  * {@link ThreadContext} instance,</p>
  *
- * <pre><code> &commat;Inject &commat;ThreadContextConfig(propagated = { ThreadContext.SECURITY, ThreadContext.APPLICATION })
+ * <pre><code> {@literal @}Inject {@literal @}ThreadContextConfig(propagated = { ThreadContext.SECURITY, ThreadContext.APPLICATION })
  * ThreadContext tc2;
  *
- * &commat;Inject &commat;ThreadContextConfig(cleared = ThreadContext.SECURITY, unchanged = ThreadContext.TRANSACTION)
+ * {@literal @}Inject {@literal @}ThreadContextConfig(cleared = ThreadContext.SECURITY, unchanged = ThreadContext.TRANSACTION)
  * ThreadContext tc3;
  * </code></pre>
  *
@@ -145,7 +145,7 @@ public @interface ThreadContextConfig {
      *
      * <p>For example, to run as the current application, but under the
      * transaction of the thread where the task executes:</p>
-     * <pre><code> &commat;Inject &commat;ThreadContextConfig(unchanged = ThreadContext.TRANSACTION,
+     * <pre><code> {@literal @}Inject {@literal @}ThreadContextConfig(unchanged = ThreadContext.TRANSACTION,
      *                              propagated = ThreadContext.APPLICATION,
      *                              cleared = ThreadContext.ALL_REMAINING)
      * ThreadContext threadContext;

--- a/cdi/pom.xml
+++ b/cdi/pom.xml
@@ -25,6 +25,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-concurrency-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
             <scope>provided</scope>

--- a/cdi/src/main/java/io/smallrye/concurrency/inject/SmallryeConcurrencyCdiExtension.java
+++ b/cdi/src/main/java/io/smallrye/concurrency/inject/SmallryeConcurrencyCdiExtension.java
@@ -15,13 +15,13 @@
  */
 package io.smallrye.concurrency.inject;
 
+import io.smallrye.concurrency.api.NamedInstance;
+import io.smallrye.concurrency.api.ManagedExecutorConfig;
+import io.smallrye.concurrency.api.ThreadContextConfig;
 import io.smallrye.concurrency.impl.ManagedExecutorBuilderImpl;
 import io.smallrye.concurrency.impl.ThreadContextBuilderImpl;
 import org.eclipse.microprofile.concurrent.ManagedExecutor;
-import org.eclipse.microprofile.concurrent.ManagedExecutorConfig;
-import org.eclipse.microprofile.concurrent.NamedInstance;
 import org.eclipse.microprofile.concurrent.ThreadContext;
-import org.eclipse.microprofile.concurrent.ThreadContextConfig;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 
@@ -52,6 +52,8 @@ import java.util.stream.Collectors;
 
 /**
  * CDI extension that takes care of injectable ThreadContext and ManagedExecutor instances.
+ *
+ * Also takes into consideration MP Config which may be used to override injection point configuration.
  *
  * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
  */

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -27,6 +27,11 @@
             <artifactId>smallrye-concurrency-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <version>${version.microprofile.config}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,6 +22,11 @@
             <groupId>org.eclipse.microprofile.concurrency</groupId>
             <artifactId>microprofile-concurrency-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-concurrency-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/core/src/main/java/io/smallrye/concurrency/SmallRyeConcurrencyManager.java
+++ b/core/src/main/java/io/smallrye/concurrency/SmallRyeConcurrencyManager.java
@@ -23,7 +23,6 @@ public class SmallRyeConcurrencyManager implements ConcurrencyManager {
     public static final String[] NO_STRING = new String[0];
 
     public static final String[] ALL_REMAINING_ARRAY = new String[] { ThreadContext.ALL_REMAINING };
-    public static final String[] TRANSACTION_ARRAY = new String[] { ThreadContext.TRANSACTION };
 
     private List<ThreadContextProvider> providers;
     private List<ConcurrencyManagerExtension> extensions;

--- a/core/src/main/java/io/smallrye/concurrency/impl/DefaultValues.java
+++ b/core/src/main/java/io/smallrye/concurrency/impl/DefaultValues.java
@@ -1,0 +1,92 @@
+package io.smallrye.concurrency.impl;
+
+import io.smallrye.concurrency.SmallRyeConcurrencyManager;
+import io.smallrye.concurrency.api.ManagedExecutorConfig;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import java.util.NoSuchElementException;
+
+/**
+ * Holds default values for {@code ManagedExecutor} and {@code ThreadContext}. It firstly looks into MP Config
+ * for any user-specified defaults and if not defined, then it uses SmallRye defaults which propagate everything.
+ *
+ * @author Matej Novotny
+ */
+public class DefaultValues {
+
+    // single instance
+    public static final DefaultValues INSTANCE = new DefaultValues();
+
+    // constants defined by spec for MP Config
+    private final String EXEC_ASYNC = "ManagedExecutor/maxAsync";
+    private final String EXEC_QUEUE = "ManagedExecutor/maxQueued";
+    private final String EXEC_PROPAGATED = "ManagedExecutor/propagated";
+    private final String EXEC_CLEARED = "ManagedExecutor/cleared";
+    private final String THREAD_CLEARED = "ThreadContext/cleared";
+    private final String THREAD_PROPAGATED = "ThreadContext/propagated";
+    private final String THREAD_UNCHANGED = "ThreadContext/unchanged";
+
+    // actual defaults
+    private String[] executorPropagated;
+    private String[] executorCleared;
+    private int executorAsync;
+    private int executorQueue;
+    private String[] threadPropagated;
+    private String[] threadCleared;
+    private String[] threadUnchanged;
+
+    private DefaultValues() {
+        // NOTE: we do not perform sanity check here, that's done in SmallRyeConcurrencyManager
+        Config config = ConfigProvider.getConfig();
+        this.executorAsync = config.getOptionalValue(EXEC_ASYNC, Integer.class)
+                .orElse(ManagedExecutorConfig.Literal.DEFAULT_INSTANCE.maxAsync());
+        this.executorQueue = config.getOptionalValue(EXEC_QUEUE, Integer.class)
+                .orElse(ManagedExecutorConfig.Literal.DEFAULT_INSTANCE.maxQueued());
+        // remaining values have to be done via try-catch block as a workaround for
+        // https://github.com/smallrye/smallrye-config/issues/83
+        // once fixed, rewrite this to getOptionalValue()
+        this.executorPropagated = resolveConfiguration(config, EXEC_PROPAGATED, SmallRyeConcurrencyManager.ALL_REMAINING_ARRAY);
+        this.executorCleared = resolveConfiguration(config, EXEC_CLEARED, SmallRyeConcurrencyManager.NO_STRING);
+        this.threadCleared = resolveConfiguration(config, THREAD_CLEARED, SmallRyeConcurrencyManager.NO_STRING);
+        this.threadPropagated = resolveConfiguration(config, THREAD_PROPAGATED, SmallRyeConcurrencyManager.ALL_REMAINING_ARRAY);
+        this.threadUnchanged = resolveConfiguration(config, THREAD_UNCHANGED, SmallRyeConcurrencyManager.NO_STRING);
+        System.err.println(config.getConfigSources());
+    }
+
+    private static String[] resolveConfiguration(Config mpConfig, String key, String[] originalValue) {
+        try {
+            return mpConfig.getValue(key, String[].class);
+        } catch (NoSuchElementException e) {
+            return originalValue;
+        }
+    }
+
+    public String[] getExecutorPropagated() {
+        return executorPropagated;
+    }
+
+    public String[] getExecutorCleared() {
+        return executorCleared;
+    }
+
+    public int getExecutorAsync() {
+        return executorAsync;
+    }
+
+    public int getExecutorQueue() {
+        return executorQueue;
+    }
+
+    public String[] getThreadPropagated() {
+        return threadPropagated;
+    }
+
+    public String[] getThreadCleared() {
+        return threadCleared;
+    }
+
+    public String[] getThreadUnchanged() {
+        return threadUnchanged;
+    }
+}

--- a/core/src/main/java/io/smallrye/concurrency/impl/DefaultValues.java
+++ b/core/src/main/java/io/smallrye/concurrency/impl/DefaultValues.java
@@ -51,7 +51,6 @@ public class DefaultValues {
         this.threadCleared = resolveConfiguration(config, THREAD_CLEARED, SmallRyeConcurrencyManager.NO_STRING);
         this.threadPropagated = resolveConfiguration(config, THREAD_PROPAGATED, SmallRyeConcurrencyManager.ALL_REMAINING_ARRAY);
         this.threadUnchanged = resolveConfiguration(config, THREAD_UNCHANGED, SmallRyeConcurrencyManager.NO_STRING);
-        System.err.println(config.getConfigSources());
     }
 
     private static String[] resolveConfiguration(Config mpConfig, String key, String[] originalValue) {

--- a/core/src/main/java/io/smallrye/concurrency/impl/ManagedExecutorBuilderImpl.java
+++ b/core/src/main/java/io/smallrye/concurrency/impl/ManagedExecutorBuilderImpl.java
@@ -1,8 +1,8 @@
 package io.smallrye.concurrency.impl;
 
+import io.smallrye.concurrency.api.SmallRyeManagedExecutorConfig;
 import org.eclipse.microprofile.concurrent.ManagedExecutor;
 import org.eclipse.microprofile.concurrent.ManagedExecutor.Builder;
-import org.eclipse.microprofile.concurrent.ManagedExecutorConfig;
 
 import io.smallrye.concurrency.SmallRyeConcurrencyManager;
 
@@ -20,8 +20,8 @@ public class ManagedExecutorBuilderImpl implements ManagedExecutor.Builder {
         // initiate with default values
         this.propagated = SmallRyeConcurrencyManager.ALL_REMAINING_ARRAY;
         this.cleared = SmallRyeConcurrencyManager.TRANSACTION_ARRAY;
-        this.maxAsync = ManagedExecutorConfig.Literal.DEFAULT_INSTANCE.maxAsync();
-        this.maxQueued = ManagedExecutorConfig.Literal.DEFAULT_INSTANCE.maxQueued();
+        this.maxAsync = SmallRyeManagedExecutorConfig.Literal.DEFAULT_INSTANCE.maxAsync();
+        this.maxQueued = SmallRyeManagedExecutorConfig.Literal.DEFAULT_INSTANCE.maxQueued();
     }
 
     @Override

--- a/core/src/main/java/io/smallrye/concurrency/impl/ManagedExecutorBuilderImpl.java
+++ b/core/src/main/java/io/smallrye/concurrency/impl/ManagedExecutorBuilderImpl.java
@@ -1,6 +1,5 @@
 package io.smallrye.concurrency.impl;
 
-import io.smallrye.concurrency.api.SmallRyeManagedExecutorConfig;
 import org.eclipse.microprofile.concurrent.ManagedExecutor;
 import org.eclipse.microprofile.concurrent.ManagedExecutor.Builder;
 
@@ -18,10 +17,10 @@ public class ManagedExecutorBuilderImpl implements ManagedExecutor.Builder {
     public ManagedExecutorBuilderImpl(SmallRyeConcurrencyManager manager) {
         this.manager = manager;
         // initiate with default values
-        this.propagated = SmallRyeConcurrencyManager.ALL_REMAINING_ARRAY;
-        this.cleared = SmallRyeConcurrencyManager.TRANSACTION_ARRAY;
-        this.maxAsync = SmallRyeManagedExecutorConfig.Literal.DEFAULT_INSTANCE.maxAsync();
-        this.maxQueued = SmallRyeManagedExecutorConfig.Literal.DEFAULT_INSTANCE.maxQueued();
+        this.propagated = DefaultValues.INSTANCE.getExecutorPropagated();
+        this.cleared = DefaultValues.INSTANCE.getExecutorCleared();
+        this.maxAsync = DefaultValues.INSTANCE.getExecutorAsync();
+        this.maxQueued = DefaultValues.INSTANCE.getExecutorQueue();
     }
 
     @Override

--- a/core/src/main/java/io/smallrye/concurrency/impl/ManagedExecutorImpl.java
+++ b/core/src/main/java/io/smallrye/concurrency/impl/ManagedExecutorImpl.java
@@ -200,4 +200,20 @@ public class ManagedExecutorImpl extends ThreadPoolExecutor implements ManagedEx
         return builder.toString();
     }
 
+    public ThreadContextProviderPlan getThreadContextProviderPlan() {
+        return threadContext.getPlan();
+    }
+
+    public int getMaxAsync() {
+        return maxAsync;
+    }
+
+    public int getMaxQueued() {
+        return maxQueued;
+    }
+
+    public String getInjectionPointName() {
+        return injectionPointName;
+    }
+
 }

--- a/core/src/main/java/io/smallrye/concurrency/impl/ThreadContextBuilderImpl.java
+++ b/core/src/main/java/io/smallrye/concurrency/impl/ThreadContextBuilderImpl.java
@@ -14,9 +14,9 @@ public class ThreadContextBuilderImpl implements ThreadContext.Builder {
 
     public ThreadContextBuilderImpl(SmallRyeConcurrencyManager manager) {
         this.manager = manager;
-        this.propagated = SmallRyeConcurrencyManager.ALL_REMAINING_ARRAY;
-        this.unchanged = SmallRyeConcurrencyManager.NO_STRING;
-        this.cleared = SmallRyeConcurrencyManager.TRANSACTION_ARRAY;
+        this.propagated = DefaultValues.INSTANCE.getThreadPropagated();
+        this.unchanged = DefaultValues.INSTANCE.getThreadUnchanged();
+        this.cleared = DefaultValues.INSTANCE.getThreadCleared();
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -188,5 +188,6 @@
         <module>propagators-rxjava2</module>
         <module>tests</module>
         <module>tck</module>
-    </modules>
+		<module>api</module>
+	</modules>
 </project>

--- a/tck/src/test/java/io/smallrye/concurrency/tck/cdi/TckManagedExecutorSharingTest.java
+++ b/tck/src/test/java/io/smallrye/concurrency/tck/cdi/TckManagedExecutorSharingTest.java
@@ -1,7 +1,0 @@
-package io.smallrye.concurrency.tck.cdi;
-
-import org.eclipse.microprofile.concurrency.tck.cdi.ManagedExecutorSharingTest;
-
-public class TckManagedExecutorSharingTest extends ManagedExecutorSharingTest {
-
-}

--- a/tests/src/main/java/io/smallrye/concurrency/test/FullStackResource.java
+++ b/tests/src/main/java/io/smallrye/concurrency/test/FullStackResource.java
@@ -90,7 +90,7 @@ public class FullStackResource {
         CompletableFuture<String> ret2 = threadContext.withContextCapture(ret);
         CompletableFuture<String> ret3 = ret2.thenApply(body -> {
             
-            //testJpa2();
+            testJpa2();
             testCdiContext();
             testTransactionalContext();
             testResteasyContext(uriInfo);

--- a/tests/src/main/java/io/smallrye/concurrency/test/FullStackResource.java
+++ b/tests/src/main/java/io/smallrye/concurrency/test/FullStackResource.java
@@ -12,9 +12,9 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.UriInfo;
 
+import io.smallrye.concurrency.api.ThreadContextConfig;
 import io.smallrye.concurrency.test.jta.TransactionalBean;
 import org.eclipse.microprofile.concurrent.ThreadContext;
-import org.eclipse.microprofile.concurrent.ThreadContextConfig;
 
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.client.WebClient;
@@ -90,7 +90,7 @@ public class FullStackResource {
         CompletableFuture<String> ret2 = threadContext.withContextCapture(ret);
         CompletableFuture<String> ret3 = ret2.thenApply(body -> {
             
-            testJpa2();
+            //testJpa2();
             testCdiContext();
             testTransactionalContext();
             testResteasyContext(uriInfo);

--- a/tests/src/test/java/io/smallrye/concurrency/test/cdi/providedBeans/BeanWithInjectionPoints.java
+++ b/tests/src/test/java/io/smallrye/concurrency/test/cdi/providedBeans/BeanWithInjectionPoints.java
@@ -1,0 +1,143 @@
+package io.smallrye.concurrency.test.cdi.providedBeans;
+
+import io.smallrye.concurrency.api.ManagedExecutorConfig;
+import io.smallrye.concurrency.api.NamedInstance;
+import io.smallrye.concurrency.api.ThreadContextConfig;
+import io.smallrye.concurrency.impl.ManagedExecutorImpl;
+import io.smallrye.concurrency.impl.ThreadContextImpl;
+import io.smallrye.concurrency.impl.ThreadContextProviderPlan;
+import io.vertx.core.cli.annotations.Name;
+import org.eclipse.microprofile.concurrent.ManagedExecutor;
+import org.eclipse.microprofile.concurrent.ThreadContext;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
+import org.hibernate.engine.spi.Managed;
+import org.jboss.weld.proxy.WeldClientProxy;
+import org.junit.Assert;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * There are multiple context providers added in tests, we do not assert on those and only look for CDI and JTA now.
+ */
+@ApplicationScoped
+public class BeanWithInjectionPoints {
+
+    @Inject
+    @ManagedExecutorConfig
+    ManagedExecutor defaultConfigExecutor;
+
+    @Inject
+    @ManagedExecutorConfig
+    @NamedInstance("sharedDefaultExecutor")
+    ManagedExecutor executor2;
+
+    @Inject
+    @NamedInstance("sharedDefaultExecutor")
+    ManagedExecutor executor3;
+
+    @Inject
+    @ManagedExecutorConfig(maxAsync = 2, maxQueued = 3, cleared = ThreadContext.CDI, propagated = ThreadContext.TRANSACTION)
+    ManagedExecutor configuredExecutor;
+
+    @Inject
+    @ThreadContextConfig
+    ThreadContext defaultThreadContext;
+
+    @Inject
+    @ThreadContextConfig
+    @NamedInstance("sharedThreadContext")
+    ThreadContext threadContext1;
+
+    @Inject
+    @NamedInstance("sharedThreadContext")
+    ThreadContext threadContext2;
+
+    @Inject
+    @ThreadContextConfig(propagated = ThreadContext.CDI, cleared = ThreadContext.TRANSACTION, unchanged = "")
+    ThreadContext configuredThreadContext;
+
+    public void assertDefaultExecutor() {
+        ManagedExecutorImpl exec = unwrapExecutor(defaultConfigExecutor);
+        Assert.assertEquals(-1,exec.getMaxAsync());
+        Assert.assertEquals(-1,exec.getMaxQueued());
+        ThreadContextProviderPlan plan = exec.getThreadContextProviderPlan();
+        Assert.assertEquals(0,plan.unchangedProviders.size());
+        Assert.assertEquals(0,plan.clearedProviders.size());
+        Set<String> propagated = providersToStringSet(plan.propagatedProviders);
+        Assert.assertTrue(propagated.contains(ThreadContext.CDI));
+        Assert.assertTrue(propagated.contains(ThreadContext.TRANSACTION));
+    }
+
+    public void assertSharedExecutorsAreTheSame() {
+        // simply unwrap both and compare reference
+        ManagedExecutorImpl shared1 = unwrapExecutor(executor2);
+        ManagedExecutorImpl shared2 = unwrapExecutor(executor3);
+        Assert.assertSame(shared1, shared2);
+    }
+
+    public void assertConfiguredManagedExecutor() {
+        ManagedExecutorImpl exec = unwrapExecutor(configuredExecutor);
+        Assert.assertEquals(2,exec.getMaxAsync());
+        Assert.assertEquals(3,exec.getMaxQueued());
+        ThreadContextProviderPlan plan = exec.getThreadContextProviderPlan();
+        Assert.assertEquals(0,plan.unchangedProviders.size());
+        Set<String> propagated = providersToStringSet(plan.propagatedProviders);
+        Set<String> cleared = providersToStringSet(plan.clearedProviders);
+        Assert.assertTrue(cleared.contains(ThreadContext.CDI));
+        Assert.assertTrue(propagated.contains(ThreadContext.TRANSACTION));
+    }
+
+    public void assertSharedThreadContextsAreTheSame() {
+        //unwrap and compare references
+        ThreadContextImpl shared1 = unwrapThreadContext(threadContext1);
+        ThreadContextImpl shared2 = unwrapThreadContext(threadContext2);
+        Assert.assertSame(shared1, shared2);
+    }
+
+    public void assertConfiguredThreadContext() {
+        ThreadContextImpl context = unwrapThreadContext(configuredThreadContext);
+        ThreadContextProviderPlan plan = context.getPlan();
+        Assert.assertEquals(0,plan.unchangedProviders.size());
+        Set<String> propagated = providersToStringSet(plan.propagatedProviders);
+        Set<String> cleared = providersToStringSet(plan.clearedProviders);
+        Assert.assertTrue(propagated.contains(ThreadContext.CDI));
+        Assert.assertTrue(cleared.contains(ThreadContext.TRANSACTION));
+    }
+
+    public void assertDefaultThreadContext() {
+        ThreadContextImpl context = unwrapThreadContext(defaultThreadContext);
+        ThreadContextProviderPlan plan = context.getPlan();
+        Assert.assertEquals(0,plan.unchangedProviders.size());
+        Assert.assertEquals(0,plan.clearedProviders.size());
+        Set<String> propagated = providersToStringSet(plan.propagatedProviders);
+        Assert.assertTrue(propagated.contains(ThreadContext.CDI));
+        Assert.assertTrue(propagated.contains(ThreadContext.TRANSACTION));
+    }
+
+    private ManagedExecutorImpl unwrapExecutor(ManagedExecutor executor) {
+        if (executor instanceof WeldClientProxy) {
+            return (ManagedExecutorImpl) ((WeldClientProxy) executor).getMetadata().getContextualInstance();
+        } else {
+            throw new IllegalStateException("Injected proxies are expected to be instance of WeldClientProxy");
+        }
+    }
+
+    private ThreadContextImpl unwrapThreadContext(ThreadContext executor) {
+        if (executor instanceof WeldClientProxy) {
+            return (ThreadContextImpl) ((WeldClientProxy) executor).getMetadata().getContextualInstance();
+        } else {
+            throw new IllegalStateException("Injected proxies are expected to be instance of WeldClientProxy");
+        }
+    }
+
+    private Set<String> providersToStringSet(Set<ThreadContextProvider> providers) {
+        Set<String> result = new HashSet<>();
+        for (ThreadContextProvider provider : providers) {
+            result.add(provider.getThreadContextType());
+        }
+        return result;
+    }
+}

--- a/tests/src/test/java/io/smallrye/concurrency/test/cdi/providedBeans/ExecutorAndThreadContextInjectionTest.java
+++ b/tests/src/test/java/io/smallrye/concurrency/test/cdi/providedBeans/ExecutorAndThreadContextInjectionTest.java
@@ -1,0 +1,32 @@
+package io.smallrye.concurrency.test.cdi.providedBeans;
+
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.junit.Test;
+
+/**
+ * Tests usage of {@link io.smallrye.concurrency.api.ManagedExecutorConfig}
+ * and {@link io.smallrye.concurrency.api.ThreadContextConfig} on injection points.
+ *
+ * @author Matej Novotny
+ */
+public class ExecutorAndThreadContextInjectionTest {
+
+    @Test
+    public void testInjectionWithConfigurationAndSharing() {
+        try (WeldContainer container = new Weld().addBeanClass(BeanWithInjectionPoints.class).initialize()) {
+            // being able to select the bean verifies that injection points are satisfied
+            BeanWithInjectionPoints bean = container.select(BeanWithInjectionPoints.class).get();
+            // since behind the scenes we use builders (which are tested in TCK), we only assert
+            // state of the objects, e.g. correct amount of queue, async, contexts propagated,...
+            bean.assertDefaultExecutor();
+            bean.assertConfiguredManagedExecutor();
+            bean.assertSharedExecutorsAreTheSame();
+
+            bean.assertConfiguredThreadContext();
+            bean.assertDefaultThreadContext();
+            bean.assertSharedThreadContextsAreTheSame();
+        }
+    }
+
+}


### PR DESCRIPTION
In order for tests to pass, we need this spec PR merged https://github.com/eclipse/microprofile-concurrency/pull/143 (TCK error).

I have created a new API module that contains the config annotations to allow for injection. I chose to keep the names of classes as they were in the spec originally but change the package to smallrye. So the files are mostly copied (including licenses to be proper) with adjustments to text here and there and with changed defaults.

Furthermore this PR defines our own defaults and allows to override them via MP Config which is already tested in TCKs. This however means that core module has to depend on MP config API but I don't think that matters.